### PR TITLE
Change backslashes in ML docstring

### DIFF
--- a/snippets/controls.json
+++ b/snippets/controls.json
@@ -1,7 +1,7 @@
 {
     "ML docstring": {
         "prefix": "\"\"\"",
-        "body": "\"\"\"${1:sumary_line}\n\nKeyword arguments:\n${2:argument} -- ${3:description}\nReturn: ${4:return_description}\n\\\"\\\"\\\"\n$0"
+        "body": "\"\"\"${1:sumary_line}\n\nKeyword arguments:\n${2:argument} -- ${3:description}\nReturn: ${4:return_description}\n\"\"\"\n$0"
     },
     "SL docstring": {
         "prefix": "\"\"",

--- a/snippets/controls.json
+++ b/snippets/controls.json
@@ -1,7 +1,7 @@
 {
     "ML docstring": {
         "prefix": "\"\"\"",
-        "body": "\\\"\\\"\\\"${1:sumary_line}\n\nKeyword arguments:\n${2:argument} -- ${3:description}\nReturn: ${4:return_description}\n\\\"\\\"\\\"\n$0"
+        "body": "\"\"\"${1:sumary_line}\n\nKeyword arguments:\n${2:argument} -- ${3:description}\nReturn: ${4:return_description}\n\\\"\\\"\\\"\n$0"
     },
     "SL docstring": {
         "prefix": "\"\"",


### PR DESCRIPTION
This snippet is escaping backslashes, which creates escaped quotation marks in Python files

Snippet creates the following code :
```python
\"\"\"sumary_line
    
Keyword arguments:
argument -- description
Return: return_description
\"\"\"
```

It should instead create this code :
```python
"""sumary_line
    
Keyword arguments:
argument -- description
Return: return_description
"""
```
