### PR TITLE
Fix "Flask super" template snippet 

### DIFF
--- a/snippets/templates.json
+++ b/snippets/templates.json
@@ -25,7 +25,7 @@
     },
     "Flask super": {
         "prefix": "fsuper",
-        "body": "{{ self.supper() }}$0"
+        "body": "{{ self.super() }}$0"
     },
     "Flask for": {
         "prefix": "ffor",


### PR DESCRIPTION
Currently the `fsuper` template snippet inserts `{{ self.supper() }}` instead of the expected `{{ self.super() }}`.
This simply fixes the typo.

Fixes #19 